### PR TITLE
Add categories and sections

### DIFF
--- a/app/assets/javascripts/categories.coffee
+++ b/app/assets/javascripts/categories.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/javascripts/sections.coffee
+++ b/app/assets/javascripts/sections.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/categories.scss
+++ b/app/assets/stylesheets/categories.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the categories controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/assets/stylesheets/sections.scss
+++ b/app/assets/stylesheets/sections.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the sections controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -1,8 +1,22 @@
 class CategoriesController < ApplicationController
-  before_action :authenticate_user!, only: [:new]
+  before_action :authenticate_user!, only: [:new, :create]
 
   def new
     @category = Category.new
   end
 
+  def create
+    @category = Category.create(category_params)
+    
+    if @category.valid?
+      redirect_to root_path
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  private
+  def category_params
+    params.require(:category).permit(:name, :description)
+  end
 end

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -1,0 +1,6 @@
+class CategoriesController < ApplicationController
+  def new
+    @category = Category.new
+  end
+
+end

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -1,4 +1,6 @@
 class CategoriesController < ApplicationController
+  before_action :authenticate_user!, only: [:new]
+
   def new
     @category = Category.new
   end

--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -1,0 +1,2 @@
+class SectionsController < ApplicationController
+end

--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -1,2 +1,8 @@
 class SectionsController < ApplicationController
+  before_action :authenticate_user!, only: [:new, :create]
+  
+  def new
+
+  end
+
 end

--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -1,8 +1,27 @@
 class SectionsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create]
-  
-  def new
 
+  def new
+    @section = Section.new
+  end
+
+  def create
+    @section = current_category.sections.create(section_params)
+
+    if @section.valid?
+      redirect_to root_path
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  private
+  def section_params
+    params.require(:section).permit(:name, :description)
+  end
+
+  def current_category
+    @current_category = Category.find(params[:category_id])
   end
 
 end

--- a/app/helpers/categories_helper.rb
+++ b/app/helpers/categories_helper.rb
@@ -1,0 +1,2 @@
+module CategoriesHelper
+end

--- a/app/helpers/sections_helper.rb
+++ b/app/helpers/sections_helper.rb
@@ -1,0 +1,2 @@
+module SectionsHelper
+end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,0 +1,2 @@
+class Category < ActiveRecord::Base
+end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,2 +1,4 @@
 class Category < ActiveRecord::Base
+  validates :name, presence: :true
+  has_many :sections
 end

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -1,0 +1,4 @@
+class Section < ActiveRecord::Base
+  validates :name, presence: :true
+  belongs_to :category
+end

--- a/app/views/categories/new.html.erb
+++ b/app/views/categories/new.html.erb
@@ -1,0 +1,11 @@
+<div>
+  <h2>Add a New Category</h2>
+  <br />
+
+  <%= simple_form_for @category do |f| %>
+    <%= f.input :name %>
+    <%= f.input :description %>
+    <%= f.submit "Add a Category" %>
+  <% end %>
+
+</div>

--- a/app/views/sections/new.html.erb
+++ b/app/views/sections/new.html.erb
@@ -1,0 +1,11 @@
+<div>
+  <h2>Add a New Section</h2>
+  <br />
+
+  <%= simple_form_for @section do |f| %>
+    <%= f.input :name %>
+    <%= f.input :description %>
+    <%= f.submit "Add a Section" %>
+  <% end %>
+
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
   root "posts#index"
 
   resources :categories, only: [:new, :create] do
-    resources :sections, only: [:new, :Create]
+    resources :sections, only: [:new, :create]
   end
   # The priority is based upon order of creation: first created -> highest priority.
   # See how all your routes lay out with "rake routes".

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,9 @@ Rails.application.routes.draw do
   devise_for :users
   root "posts#index"
 
-  resources :categories, only: [:new, :create]
+  resources :categories, only: [:new, :create] do
+    resources :sections, only: [:new, :Create]
+  end
   # The priority is based upon order of creation: first created -> highest priority.
   # See how all your routes lay out with "rake routes".
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,8 @@
 Rails.application.routes.draw do
   devise_for :users
   root "posts#index"
+
+  resources :categories, only: [:new, :create]
   # The priority is based upon order of creation: first created -> highest priority.
   # See how all your routes lay out with "rake routes".
 

--- a/db/migrate/20160402012023_create_categories.rb
+++ b/db/migrate/20160402012023_create_categories.rb
@@ -1,0 +1,9 @@
+class CreateCategories < ActiveRecord::Migration
+  def change
+    create_table :categories do |t|
+      t.string :name, null: false
+      t.string :description
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20160402012357_create_sections.rb
+++ b/db/migrate/20160402012357_create_sections.rb
@@ -1,0 +1,9 @@
+class CreateSections < ActiveRecord::Migration
+  def change
+    create_table :sections do |t|
+      t.integer :category_id
+      t.string :name, null: false
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20160402012656_alter_sections_add_index_on_category_id.rb
+++ b/db/migrate/20160402012656_alter_sections_add_index_on_category_id.rb
@@ -1,0 +1,5 @@
+class AlterSectionsAddIndexOnCategoryId < ActiveRecord::Migration
+  def change
+    add_index :sections, :category_id
+  end
+end

--- a/db/migrate/20160402015808_alter_sections_add_description_column.rb
+++ b/db/migrate/20160402015808_alter_sections_add_description_column.rb
@@ -1,0 +1,5 @@
+class AlterSectionsAddDescriptionColumn < ActiveRecord::Migration
+  def change
+    add_column :sections, :description, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160402012656) do
+ActiveRecord::Schema.define(version: 20160402015808) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -28,6 +28,7 @@ ActiveRecord::Schema.define(version: 20160402012656) do
     t.string   "name",        null: false
     t.datetime "created_at",  null: false
     t.datetime "updated_at",  null: false
+    t.string   "description"
   end
 
   add_index "sections", ["category_id"], name: "index_sections_on_category_id", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,10 +11,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160331232622) do
+ActiveRecord::Schema.define(version: 20160402012023) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "categories", force: :cascade do |t|
+    t.string   "name",        null: false
+    t.string   "description"
+    t.datetime "created_at",  null: false
+    t.datetime "updated_at",  null: false
+  end
 
   create_table "users", force: :cascade do |t|
     t.string   "email",                  default: "", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160402012023) do
+ActiveRecord::Schema.define(version: 20160402012656) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -22,6 +22,15 @@ ActiveRecord::Schema.define(version: 20160402012023) do
     t.datetime "created_at",  null: false
     t.datetime "updated_at",  null: false
   end
+
+  create_table "sections", force: :cascade do |t|
+    t.integer  "category_id"
+    t.string   "name",        null: false
+    t.datetime "created_at",  null: false
+    t.datetime "updated_at",  null: false
+  end
+
+  add_index "sections", ["category_id"], name: "index_sections_on_category_id", using: :btree
 
   create_table "users", force: :cascade do |t|
     t.string   "email",                  default: "", null: false

--- a/spec/controllers/categories_controller_spec.rb
+++ b/spec/controllers/categories_controller_spec.rb
@@ -40,7 +40,6 @@ RSpec.describe CategoriesController, type: :controller do
       category = Category.last
       expect(category.name).to eq("News")
       expect(category.description).to eq("A place for news")
-      expect(category.user).to eq(user)
     end
 
     it "should not allow a blank name" do
@@ -54,7 +53,7 @@ RSpec.describe CategoriesController, type: :controller do
       category_pre_count = Category.count
       post :create, category: {name: '', description: "A place for news"}
       expect(response).to have_http_status(:unprocessable_entity)
-      expect(category_count).to eq Category.count
+      expect(category_pre_count).to eq Category.count
     end
   end
 end

--- a/spec/controllers/categories_controller_spec.rb
+++ b/spec/controllers/categories_controller_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe CategoriesController, type: :controller do
+  describe "categories#new action" do
+    it "should require users to be logged in" do
+      get :new
+      expect(response).to redirect_to new_user_session_path
+    end
+
+    it "should successfully show the new form" do
+      user = User.create(
+        email:                 'fakeuser@gmail.com',
+        password:              'secretPassword',
+        password_confirmation: 'secretPassword'
+      )
+      sign_in user
+
+      get :new
+      expect(response).to have_http_status(:success)
+    end
+  end
+end

--- a/spec/controllers/categories_controller_spec.rb
+++ b/spec/controllers/categories_controller_spec.rb
@@ -19,4 +19,42 @@ RSpec.describe CategoriesController, type: :controller do
       expect(response).to have_http_status(:success)
     end
   end
+
+  describe "categories#create action" do
+    it "should require users to be logged in" do
+      post :create, category: {name: "News", description: "A place for news"}
+      expect(response).to redirect_to new_user_session_path
+    end
+
+    it "should successfully create a category in the database" do
+      user = User.create(
+        email:                 'fakeuser@gmail.com',
+        password:              'secretPassword',
+        password_confirmation: 'secretPassword'
+      )
+      sign_in user
+      
+      post :create, category: {name: 'News', description: "A place for news"}
+      expect(response).to redirect_to root_path
+
+      category = Category.last
+      expect(category.name).to eq("News")
+      expect(category.description).to eq("A place for news")
+      expect(category.user).to eq(user)
+    end
+
+    it "should not allow a blank name" do
+      user = User.create(
+        email:                 'fakeuser@gmail.com',
+        password:              'secretPassword',
+        password_confirmation: 'secretPassword'
+      )
+      sign_in user
+
+      category_pre_count = Category.count
+      post :create, category: {name: '', description: "A place for news"}
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(category_count).to eq Category.count
+    end
+  end
 end

--- a/spec/controllers/sections_controller_spec.rb
+++ b/spec/controllers/sections_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe SectionsController, type: :controller do
+
+end

--- a/spec/controllers/sections_controller_spec.rb
+++ b/spec/controllers/sections_controller_spec.rb
@@ -1,5 +1,60 @@
 require 'rails_helper'
 
 RSpec.describe SectionsController, type: :controller do
+  describe "sections#new action" do
+    it "should require users to be logged in" do
+      get :new, :category_id => 1
+      expect(response).to redirect_to new_user_session_path
+    end
 
+    it "should successfully show the new form" do
+      user = User.create(
+        email:                 'fakeuser@gmail.com',
+        password:              'secretPassword',
+        password_confirmation: 'secretPassword'
+      )
+      sign_in user
+
+      get :new, :category_id => 1
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "sections#create action" do
+    it "should require users to be logged in" do
+      post :create, :category_id => 1, section: {name: "Intros", description: "A place for intros"}
+      expect(response).to redirect_to new_user_session_path
+    end
+
+    it "should successfully create a section in the database" do
+      user = User.create(
+        email:                 'fakeuser@gmail.com',
+        password:              'secretPassword',
+        password_confirmation: 'secretPassword'
+      )
+      sign_in user
+      
+      post :create, :category_id => 1, section: {name: 'Intros', description: "A place for intros"}
+      expect(response).to redirect_to root_path
+
+      section = Section.last
+      expect(section.name).to eq("Intros")
+      expect(section.description).to eq("A place for intros")
+      expext(section.category).to_eq(1)
+    end
+
+    it "should not allow a blank name" do
+      user = User.create(
+        email:                 'fakeuser@gmail.com',
+        password:              'secretPassword',
+        password_confirmation: 'secretPassword'
+      )
+      sign_in user
+
+      section_pre_count = Section.count
+      post :create, :category_id => 1, section: {name: '', description: "A place for intros"}
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(section_pre_count).to eq Section.count
+    end
+  end
 end

--- a/spec/controllers/sections_controller_spec.rb
+++ b/spec/controllers/sections_controller_spec.rb
@@ -3,11 +3,13 @@ require 'rails_helper'
 RSpec.describe SectionsController, type: :controller do
   describe "sections#new action" do
     it "should require users to be logged in" do
-      get :new, :category_id => 1
+      test_category = Category.create(name: "test", description: "test")
+      get :new, :category_id => test_category
       expect(response).to redirect_to new_user_session_path
     end
 
     it "should successfully show the new form" do
+      test_category = Category.create(name: "test", description: "test")
       user = User.create(
         email:                 'fakeuser@gmail.com',
         password:              'secretPassword',
@@ -15,18 +17,20 @@ RSpec.describe SectionsController, type: :controller do
       )
       sign_in user
 
-      get :new, :category_id => 1
+      get :new, :category_id => test_category
       expect(response).to have_http_status(:success)
     end
   end
 
   describe "sections#create action" do
     it "should require users to be logged in" do
-      post :create, :category_id => 1, section: {name: "Intros", description: "A place for intros"}
+      test_category = Category.create(name: "test", description: "test")
+      post :create, :category_id => test_category, section: {name: "Intros", description: "A place for intros"}
       expect(response).to redirect_to new_user_session_path
     end
 
     it "should successfully create a section in the database" do
+      test_category = Category.create(name: "test", description: "test")
       user = User.create(
         email:                 'fakeuser@gmail.com',
         password:              'secretPassword',
@@ -34,16 +38,18 @@ RSpec.describe SectionsController, type: :controller do
       )
       sign_in user
       
-      post :create, :category_id => 1, section: {name: 'Intros', description: "A place for intros"}
+      post :create, :category_id => test_category, section: {name: 'Intros', description: "A place for intros"}
       expect(response).to redirect_to root_path
 
       section = Section.last
       expect(section.name).to eq("Intros")
       expect(section.description).to eq("A place for intros")
-      expext(section.category).to_eq(1)
+      expect(section.category).to eq(test_category)
     end
 
     it "should not allow a blank name" do
+      test_category = Category.create(name: "test", description: "test")
+
       user = User.create(
         email:                 'fakeuser@gmail.com',
         password:              'secretPassword',
@@ -52,7 +58,7 @@ RSpec.describe SectionsController, type: :controller do
       sign_in user
 
       section_pre_count = Section.count
-      post :create, :category_id => 1, section: {name: '', description: "A place for intros"}
+      post :create, :category_id => test_category, section: {name: '', description: "A place for intros"}
       expect(response).to have_http_status(:unprocessable_entity)
       expect(section_pre_count).to eq Section.count
     end

--- a/spec/factories/categories.rb
+++ b/spec/factories/categories.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :category do
+    
+  end
+end

--- a/spec/factories/sections.rb
+++ b/spec/factories/sections.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :section do
+    
+  end
+end

--- a/spec/helpers/categories_helper_spec.rb
+++ b/spec/helpers/categories_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the CategoriesHelper. For example:
+#
+# describe CategoriesHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe CategoriesHelper, type: :helper do
+ 
+end

--- a/spec/helpers/sections_helper_spec.rb
+++ b/spec/helpers/sections_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the SectionsHelper. For example:
+#
+# describe SectionsHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe SectionsHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/helpers/sections_helper_spec.rb
+++ b/spec/helpers/sections_helper_spec.rb
@@ -11,5 +11,5 @@ require 'rails_helper'
 #   end
 # end
 RSpec.describe SectionsHelper, type: :helper do
-  pending "add some examples to (or delete) #{__FILE__}"
+ 
 end

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Category, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
 
 RSpec.describe Category, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+ 
 end

--- a/spec/models/section_spec.rb
+++ b/spec/models/section_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Section, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/section_spec.rb
+++ b/spec/models/section_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
 
-RSpec.describe Section, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+RSpec.describe Section, type: :model do 
+  
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -27,6 +27,10 @@ require 'rspec/rails'
 ActiveRecord::Migration.maintain_test_schema!
 
 RSpec.configure do |config|
+  # Test helpers for Devise
+  config.include Devise::TestHelpers, type: :controller
+  config.include Devise::TestHelpers, type: :view
+
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
 


### PR DESCRIPTION
I added a Category model and a Section model; Categories (like the "LPP Program" and the "LPP Meeting Place" headings in the Wireframes) have many Sections (like the "News", "Intros", "Finished Projects", etc.) blocks under the categories.

I added forms to create new categories and sections, though links to them aren't currently available anywhere in the app.

Also, you can only create new categories/sections if you're logged in. Only admins should be able to do this in the future.

(And the forms aren't pretty yet--I didn't want to mess with anyone's CSS plans!)