### PR TITLE
Link to user profile (bug fix)

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -26,7 +26,7 @@
       </ul>
       <ul class="nav navbar-nav navbar-right">
           <% if user_signed_in? %>
-            <li><%= link_to 'My Profile', "user_path(current_user)" %></li>
+            <li><%= link_to 'My Profile', user_path(current_user) %></li>
             <li><%=  link_to 'Sign out', destroy_user_session_path, method: :delete  %></li>
           <% else %>
             <li><%=  link_to 'Log in', new_user_session_path  %></li>


### PR DESCRIPTION
Remove quotation marks from link to `user_path(current_user)` in header.