### PR TITLE
Assets not showing in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -28,8 +28,8 @@ Rails.application.configure do
   config.assets.js_compressor = :uglifier
   # config.assets.css_compressor = :sass
 
-  # Do not fallback to assets pipeline if a precompiled asset is missed.
-  config.assets.compile = false
+  # Do fallback to assets pipeline if a precompiled asset is missed.
+  config.assets.compile = true
 
   # Asset digests allow you to set far-future HTTP expiration dates on all assets,
   # yet still be able to expire them through the digest params.


### PR DESCRIPTION
Configure production to fall back to assets pipeline if precompiled asset is missed.