### PR TITLE
Changed redirect path upon #create actions. ~AMP

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -21,7 +21,7 @@ class CategoriesController < ApplicationController
     @category = Category.create(category_params)
     
     if @category.valid?
-      redirect_to root_path
+      redirect_to categories_path
     else
       render :new, status: :unprocessable_entity
     end

--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -10,7 +10,7 @@ class SectionsController < ApplicationController
     @section = current_category.sections.create(section_params)
 
     if @section.valid?
-      redirect_to root_path
+      redirect_to category_path(current_category)
     else
       render :new, status: :unprocessable_entity
     end

--- a/spec/controllers/categories_controller_spec.rb
+++ b/spec/controllers/categories_controller_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe CategoriesController, type: :controller do
       assert user.admin?
       
       post :create, category: {name: 'News', description: "A place for news"}
-      expect(response).to redirect_to root_path
+      expect(response).to redirect_to categories_path
 
       category = Category.last
       expect(category.name).to eq("News")

--- a/spec/controllers/sections_controller_spec.rb
+++ b/spec/controllers/sections_controller_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe SectionsController, type: :controller do
       sign_in user
       assert user.admin?
       post :create, :category_id => test_category, section: {name: 'Intros', description: "A place for intros"}
-      expect(response).to redirect_to root_path
+      expect(response).to redirect_to category_path(test_category)
 
       section = Section.last
       expect(section.name).to eq("Intros")


### PR DESCRIPTION
I fixed the redirect for Section#create to redirect to the category_path (issue #76) and while I was at it I changed the redirect for Category#create to redirect to the categories_path because that seemed to be appropriate.