### PR TITLE
Display post titles on categories index

### DIFF
--- a/app/assets/stylesheets/master.scss
+++ b/app/assets/stylesheets/master.scss
@@ -314,11 +314,11 @@ p {
     text-decoration: none !important;
   }
 
-  .listbox, .panel-heading{
+  .listbox, .panel-heading{ // category heading 
     border-radius: 0 !important;
     margin: 0 !important;
     padding: 15px;
-    background-color: #B7B7B7 !important;
+    background-color: #8b9f23 !important;
     border-left: 10px solid #1D1F20 !important;
     outline: none;
     border-radius: 0;
@@ -329,15 +329,29 @@ p {
     font-weight: bolder;
   }
 
-  .nested-panel-heading {
+
+  .nested-panel-heading  { // section heading 
     border-radius: 0 !important;
     margin: 0 !important;
     padding: 15px;
     background-color: #D1D1D1 !important;
-    border-left: 10px solid #636A6E !important;
+    border-left: 10px solid #535F15 !important; // indentation marker before section heading
     outline: none;
     border-radius: 0;
     text-transform: uppercase;
+
+    .panel-title a {
+      color: #535F15 !important;
+    }
+
+    .panel-title span a {
+    font-size: 10px;
+    font-weight: bold;
+    color: #EEEEEE !important;
+    border-radius: 18px;
+    background-color: #5d6367;
+    padding: 8px 10px;
+    }
   }
 
   .panel-default {
@@ -353,6 +367,7 @@ p {
   .panel-collapse>a{
     padding-left: 20px !important;
   }
+
   .panel-title>a{
     color: #1D1F20 !important;
     font-weight: bolder;
@@ -362,7 +377,7 @@ p {
     font-weight: bold;
     color: #EEEEEE !important;
     border-radius: 18px;
-    background-color: #C0C0C0;
+    background-color: #535F15;
     padding: 8px 10px;
   }
   .panel-title span a:hover {

--- a/app/assets/stylesheets/master.scss
+++ b/app/assets/stylesheets/master.scss
@@ -318,7 +318,7 @@ p {
     border-radius: 0 !important;
     margin: 0 !important;
     padding: 15px;
-    background-color: #D1D1D1 !important;
+    background-color: #B7B7B7 !important;
     border-left: 10px solid #1D1F20 !important;
     outline: none;
     border-radius: 0;
@@ -328,6 +328,18 @@ p {
   .panel-heading a:hover{
     font-weight: bolder;
   }
+
+  .nested-panel-heading {
+    border-radius: 0 !important;
+    margin: 0 !important;
+    padding: 15px;
+    background-color: #D1D1D1 !important;
+    border-left: 10px solid #636A6E !important;
+    outline: none;
+    border-radius: 0;
+    text-transform: uppercase;
+  }
+
   .panel-default {
     background-color: #F5F5F5 !important;
     margin: 0px !important;

--- a/app/views/categories/index.html.erb
+++ b/app/views/categories/index.html.erb
@@ -11,12 +11,12 @@
   <% @category.each do |category| %>
   <div class="panel panel-default">
     <div class="panel-heading" role="tab" id="heading<%=category.id%>">
-      <h4 class="panel-title">
+      <h3 class="panel-title">
           <%= link_to category.name, "#category#{category.id}", role: :button,
           data: { parent: '#accordion', toggle: :collapse },
           aria: { controls: "icon-indicator", expanded: true } %>
           <span class="pull-right"><%= link_to "add section", category_path(category) %></span>
-      </h4>
+      </h3>
     </div>
     <div id="category<%=category.id%>" class="panel-collapse collapse" role="tabpanel" aria-labelledby="heading<%=category.id%>">
         <% category.sections.each do |section| %>

--- a/app/views/categories/index.html.erb
+++ b/app/views/categories/index.html.erb
@@ -20,9 +20,19 @@
     </div>
     <div id="category<%=category.id%>" class="panel-collapse collapse" role="tabpanel" aria-labelledby="heading<%=category.id%>">
         <% category.sections.each do |section| %>
-          <div class="list-group">
-            <p> <%= link_to section.name , sections_path(section.id) %> - <span class="pull-right"><%= link_to "add post", new_section_post_path(section)%></span></p>
+          <div class="nested-panel-heading" role="tab" id="heading<%=category.id%>">          
+            <h4 class="panel-title">
+              <%= link_to section.name, "#section#{section.id}", role: :button,
+              data: { parent: '#accordion', toggle: :collapse },
+              aria: { controls: "icon-indicator", expanded: true } %>
+              <span class="pull-right"><%= link_to "add post", new_section_post_path(section) %></span>
+            </h4>
           </div>
+          <% section.posts.each do |post| %>
+            <div class="list-group">
+              <p> <%= link_to post.title, post_path(post) %> </p>
+            </div>
+          <% end %>
         <% end %>
     </div>
   </div>


### PR DESCRIPTION
So @amarkpark and I were pairing to fix #124... we thought it would be a good idea to list posts in a different way (and also fix #110 & #111 in the same go).

There's still some work to be done (Markdown is still being iffy, and we'd like to entertain the idea of listing all the sections and collapsing the posts instead), but those will be addressed in separate issues.

@cacauzen -- Please tell us what you think about this way of displaying the main page (and also on the colour scheme!)

![show-post-titles](https://cloud.githubusercontent.com/assets/3732709/14771235/71966a3a-0a52-11e6-8432-8db478d8d952.png)
