### PR TITLE
Post shows how long ago it was created

### DIFF
--- a/app/assets/stylesheets/master.scss
+++ b/app/assets/stylesheets/master.scss
@@ -289,6 +289,10 @@ p {
   padding-left: 5px !important;
   margin: 15px !important;
 }
+.list-group p.post-description {
+  color: #A9A9A9;
+  font-size: 12px;
+}
 .list-group p:hover{
   border-left: 4px solid #8B9F23;
 }

--- a/app/views/categories/index.html.erb
+++ b/app/views/categories/index.html.erb
@@ -43,6 +43,8 @@
           <% section.posts.each do |post| %>
             <div class="list-group">
               <p> <%= link_to post.title, post_path(post) %> </p>
+              <p class="post-description"> Posted: <%= time_ago_in_words(post.created_at) %> ago </p>
+              
             </div>
           <% end %>
         <% end %>


### PR DESCRIPTION
fix #128 

Shows when post was created. 
![screenshot 2016-04-26 12 20 36](https://cloud.githubusercontent.com/assets/1056543/14827949/6198ae64-0baa-11e6-9e4a-b8f673b9724d.png)
