### PR TITLE
general cleanup and style tweaks ~AMP

### DIFF
--- a/app/assets/stylesheets/master.scss
+++ b/app/assets/stylesheets/master.scss
@@ -10,6 +10,11 @@ html {
   width: 100%;
   min-height: 100%;
 }
+
+.clr {
+  clear:both;
+}
+
 .alert{
   position: absolute;
   z-index: 200;
@@ -186,10 +191,6 @@ p {
 .slogantext {
   font-size: 17px;
   text-transform: uppercase;
-}
-
-.clr {
-  clear:both;
 }
 
 .listbox{

--- a/app/views/categories/index.html.erb
+++ b/app/views/categories/index.html.erb
@@ -6,7 +6,6 @@
       <%= link_to "Add New Category", new_category_path %> &lt;
     <% end %>
 
-    <span><%= link_to "See all posts", posts_path %></span>
     </h4>
   </div>
   <br />
@@ -55,4 +54,4 @@
 <!--Testing accordion feature-->
 
 </div>
-<br class="clear">
+<br class="clr" />

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,8 +2,8 @@
 <html>
 <head>
   <title>LetsPairProgram</title>
-  <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true %>
-  <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
+  <%= stylesheet_link_tag    'application', media: 'all' %>
+  <%= javascript_include_tag 'application' %>
   <!--Load Bootstrap css-->
   <link href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.0/css/bootstrap.min.css" rel="stylesheet">
   <!--load font awesome-->
@@ -12,47 +12,50 @@
 </head>
 <body>
   <nav class="nav navbar navbar-default navbar-fixed-top" role="navigation">
-  <div class="container-fluid">
-    <!-- Brand and toggle get grouped for better mobile display -->
-    <div class="navbar-header">
-      <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#bs-example-navbar-collapse-1">
-        <span class="sr-only">Toggle navigation</span>
-        <span class="icon-bar"></span>
-        <span class="icon-bar"></span>
-        <span class="icon-bar"></span>
-      </button>
-      <%= link_to "LPP", root_path, class: 'navbar-brand' %>
-      <%= link_to "SESSION", categories_path, class: 'navbar-brand' %>
-    </div>
+    <div class="container-fluid">
+      <!-- Brand and toggle get grouped for better mobile display -->
+      <div class="navbar-header">
+        <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#bs-example-navbar-collapse-1">
+          <span class="sr-only">Toggle navigation</span>
+          <span class="icon-bar"></span>
+          <span class="icon-bar"></span>
+          <span class="icon-bar"></span>
+        </button>
+        <%= link_to "LPP", root_path, class: 'navbar-brand' %>
+      </div>
 
-    <!-- Collect the nav links, forms, and other content for toggling -->
-    <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
-      <ul class="nav navbar-nav">
-      </ul>
-      <ul class="nav navbar-nav navbar-right">
-          <% if user_signed_in? %>
-            <li><%= link_to 'My Profile', user_path(current_user) %></li>
-            <li><%=  link_to 'Sign out', destroy_user_session_path, method: :delete  %></li>
-          <% else %>
-            <li><%=  link_to 'Log in', new_user_session_path  %></li>
-            <li><%=  link_to 'Sign Up', new_user_registration_path  %></li>
-          <% end %>
-      </ul>
-    </div><!-- /.navbar-collapse -->
-  </div><!-- /.container-fluid -->
-</nav>
+      <!-- Collect the nav links, forms, and other content for toggling -->
+      <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
+          <ul class="nav navbar-nav">
+            <% if user_signed_in? %>
+              <li><%= link_to "Return To Categories", categories_path %></li>
+              <li><%= link_to "See all posts", posts_path %></li>
+            <% end %>
+          </ul>
+        <ul class="nav navbar-nav navbar-right">
+            <% if user_signed_in? %>
+              <li><%= link_to 'My Profile', user_path(current_user) %></li>
+              <li><%=  link_to 'Sign out', destroy_user_session_path, method: :delete  %></li>
+            <% else %>
+              <li><%=  link_to 'Log in', new_user_session_path  %></li>
+              <li><%=  link_to 'Sign Up', new_user_registration_path  %></li>
+            <% end %>
+        </ul>
+      </div><!-- /.navbar-collapse -->
+    </div><!-- /.container-fluid -->
+  </nav>
 
   <% if notice.present? %>
-  <p class="alert alert-info"><%= notice %></p>
+    <p class="alert alert-info"><%= notice %></p>
   <% end %>
 
   <% if alert.present? %>
-  <p class="alert alert-danger"><%= alert %></p>
+   <p class="alert alert-danger"><%= alert %></p>
   <% end %>
+
   <%= yield %>
 
-  <br class="clr"/>
-  <br />
+  <div class="clr"></div>
 
   <div id="footer">
     <br />

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,23 +1,17 @@
 
 <div class="col-xs-10 col-xs-offset-1">
   <% @categories.each do |category| %>
-
     <h1><%= category.name %></h1>
-
-    <div class="col-xs-offset-1">
-    <% category.sections.each do |section| %>
-      <h2><%= section.name %></h2>
-
-        <div class="col-xs-offset-1">
-        <% section.posts.each do |post| %>
-          <h3><%= link_to post.title, post_path(post) %></h3>
+      <div class="col-xs-offset-1">
+        <% category.sections.each do |section| %>
+          <h2><%= section.name %></h2>
+            <div class="col-xs-offset-1">
+              <% section.posts.each do |post| %>
+                <h3><%= link_to post.title, post_path(post) %></h3>
+              <% end %>
+            </div>
         <% end %>
-        </div>
-
-    <% end %>
-  </div>
-
+      </div>
   <% end %>
-
 </div>
 <br class="clr" />

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -4,15 +4,20 @@
 
     <h1><%= category.name %></h1>
 
+    <div class="col-xs-offset-1">
     <% category.sections.each do |section| %>
       <h2><%= section.name %></h2>
 
+        <div class="col-xs-offset-1">
         <% section.posts.each do |post| %>
           <h3><%= link_to post.title, post_path(post) %></h3>
         <% end %>
+        </div>
 
     <% end %>
+  </div>
 
   <% end %>
 
 </div>
+<br class="clr" />

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -10,7 +10,6 @@
 </script>
 
 <br />
-<br />
 <div class="col-xs-10 col-xs-offset-1">
   <div class="col-md-6">
     <div class="">
@@ -52,4 +51,5 @@
   </div>
 </div>
 
-<br class="clear">
+<br class="clr" />
+<br />

--- a/app/views/static_pages/press.html.erb
+++ b/app/views/static_pages/press.html.erb
@@ -1,11 +1,11 @@
 <div class="splash_four">
-    <div class="splashbody">
-        <div class="container">
-        	<div class="col-md-8 col-md-offset-2">
-	        	<div class="press">
-	        		<h1>Coming Soon!</h1>
-	    		</div>
-    		</div>
+  <div class="splashbody">
+    <div class="container">
+      <div class="col-md-8 col-md-offset-2">
+        <div class="press">
+	        <h1>Coming Soon!</h1>
+	    	</div>
+    	</div>
 		</div>
 	</div>
 </div>

--- a/app/views/static_pages/terms.html.erb
+++ b/app/views/static_pages/terms.html.erb
@@ -92,4 +92,3 @@
   <p>The limitations and exclusions of liability set out in this Section and elsewhere in this disclaimer: (a) are subject to the preceding paragraph; and (b) govern all liabilities arising under the disclaimer or in relation to the subject matter of this disclaimer, including liabilities arising in contract, in tort (including negligence) and for breach of statutory duty.</p>
   <p>To the extent that the website and the information and services on the website are provided free of charge, we will not be liable for any loss or damage of any nature.</p>
 </div>
-<br class="clear">


### PR DESCRIPTION
- I moved the CSS clr up to the top of the master.scss to make it easy to find because some of the clears were spelled out all the way but in this app there was an abbreviation.  I changed all instances of `class="clear"` to `class="clr"`, changed the style of a link in the topnav, cleaned up a bit of nesting, cleaned up a reference to tracking turbolinks
- I changed app layout clr from a `<br>` to a `<div>` to let static page splash images sit flush against the footer.
- I added simple nesting to posts#index page.