### PR TITLE
Admin can delete post

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,8 +1,16 @@
 class PostsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create, :reply]
+  before_action :confirm_admin, only: [:destroy]
 
 	def index
     @categories = Category.all
+	end
+	
+	def destroy
+	  @post = Post.find_by_id(params[:id])
+	  @post.destroy
+	  flash[:notice] = "Post deleted."
+	  redirect_to categories_path
 	end
 
   def new

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -2,6 +2,6 @@ class Post < ActiveRecord::Base
   belongs_to :section
   belongs_to :user
   belongs_to :parent_post, :class_name => "Post", :foreign_key => "parent_post_id"
-  has_many :replies, :class_name => "Post", :foreign_key => "parent_post_id"
+  has_many :replies, :class_name => "Post", :foreign_key => "parent_post_id", :dependent => :destroy
 
 end

--- a/app/views/categories/index.html.erb
+++ b/app/views/categories/index.html.erb
@@ -36,8 +36,14 @@
           </div>
           <% section.posts.each do |post| %>
             <div class="list-group">
-              <p> <%= link_to post.title, post_path(post) %> </p>
-              <p class="post-description"> Posted: <%= time_ago_in_words(post.created_at) %> ago </p>
+              
+              <p> <%= link_to post.title, post_path(post) %>
+              <% if current_user.admin %>
+              <span class="pull-right"><%= link_to 'delete post', post_path(post), method: :delete, data:{confirm: "Are you sure?"} %></span>
+              <% end %> 
+              </p>
+              
+              <p class="post-description"> Posted: <%= time_ago_in_words(post.created_at) %> ago</p>
             </div>
           <% end %>
         <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,7 +16,7 @@ Rails.application.routes.draw do
 
   resources :users, only: :show
 
-  resources :posts, only: [:index, :show] do
+  resources :posts, only: [:index, :show, :destroy] do
     member do
       post :reply
     end

--- a/spec/controllers/posts_controller_spec.rb
+++ b/spec/controllers/posts_controller_spec.rb
@@ -107,4 +107,23 @@ RSpec.describe PostsController, type: :controller do
       expect(reply.user).to eq(user)
     end    
   end
+  
+  describe "post#destroy" do
+      it "should delete the post from the database" do
+          post = FactoryGirl.create(:post)
+          delete :destroy, id: post.id
+          expect(response).to redirect_to categories_path
+          post = Post.find_by_id(post.id)
+          expect(post).to eq nil
+      end
+      
+      it "should allow an admin to delete a post" do
+        post = FactoryGirl.create(:post)
+        user = FactoryGirl.create(:user, admin: true)
+        sign_in user
+        assert user.admin?
+        delete :destroy, id: post.id
+        expect(response).to redirect_to categories_path
+      end
+  end
 end


### PR DESCRIPTION
#80 Should remove all replies when the parent post is deleted.

Not in this pull-
users deleting their own posts
removing individual posts(replies)
